### PR TITLE
ADD: Users can't request a space for dates outside of available range

### DIFF
--- a/spec/features/request_a_booking_spec.rb
+++ b/spec/features/request_a_booking_spec.rb
@@ -21,4 +21,13 @@ feature 'Request a booking' do
     expect(page).to have_content "2020-07-22"
     expect(page).to have_content "Pending"
   end
+  scenario "a user can not request a booking not in space's available range" do
+    user_sign_up('johnnylandlord@landlords.com', 'moneymoneymoney')
+    add_space("Bob's Bunker", 'My bunker is amazing', '50', '2019-04-20', '2019-04-29')
+    user_sign_up('billyrenter@renters.com', 'love2rent')
+    visit '/spaces'
+    click_link 'Request to book'
+    expect(find('#booking_date')['min']).to eq('2019-04-20')
+    expect(find('#booking_date')['max']).to eq('2019-04-29')
+  end
 end

--- a/views/request/new.erb
+++ b/views/request/new.erb
@@ -6,7 +6,7 @@
             <input type="hidden" name="space_id" value="<%= @space.id %>">
             <div class="form-group">
                 <label for="booking_date">Booking date</label>
-                <input type="date" class="form-control" id="booking_date" name="booking_date">
+                <input type="date" class="form-control" id="booking_date" name="booking_date" min='<%= @space.start_date %>' max='<%= @space.end_date %>'>
             </div>
             <button type="submit" class="btn btn-primary">Request to book</button>
         </form>


### PR DESCRIPTION
Amended the requests/new erb to include a min and max value for the date input that are populated from the start_date and end-date values of that space