### PR TITLE
Display correct menu options depending on logged in status

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,12 @@
 require 'sinatra/base'
+require_relative 'app/helpers/users'
 require_relative 'lib/request'
 require_relative 'lib/space'
 require_relative 'lib/user'
 require_relative 'lib/connect_to_database'
 
 class MakersBnB < Sinatra::Base
+  include Sinatra::UsersHelpers
   enable :sessions
 
   get '/' do
@@ -12,11 +14,12 @@ class MakersBnB < Sinatra::Base
   end
 
   get '/spaces/new' do
+    @user = current_user
     erb :'spaces/new'
   end
 
   post '/spaces' do
-    user = User.get(session[:user_id])
+    user = current_user
     Space.create(name: params[:name],
                  description: params[:description],
                  price: params[:price],
@@ -35,19 +38,19 @@ class MakersBnB < Sinatra::Base
 
   get '/spaces' do
     @spaces = Space.all
-    @user = User.get(session[:user_id])
+    @user = current_user
     erb :spaces
   end
 
   get '/requests/new/:space_id' do
     @space = Space.get(params[:space_id])
-    @user = User.get(session[:user_id])
+    @user = current_user
     erb :"request/new"
   end
 
   post '/requests' do
     @space = Space.get(params[:space_id])
-    @user = User.get(session[:user_id])
+    @user = current_user
     Request.create(space: @space,
                    user: @user,
                    date: params[:booking_date])
@@ -83,6 +86,7 @@ class MakersBnB < Sinatra::Base
   end
 
   get '/sessions/new' do
+    @user = current_user
     erb :'sessions/new'
   end
 

--- a/app/helpers/users.rb
+++ b/app/helpers/users.rb
@@ -1,0 +1,19 @@
+require 'sinatra/base'
+
+module Sinatra
+  module UsersHelpers  
+    def logged_in?
+      !not_logged_in?
+    end
+
+    def not_logged_in?
+      session[:user_id].nil?
+    end
+
+    def current_user
+      User.get(session[:user_id])
+    end
+  end
+
+  helpers UsersHelpers
+end

--- a/spec/features/confirm_booking_spec.rb
+++ b/spec/features/confirm_booking_spec.rb
@@ -2,8 +2,10 @@ feature 'Confirm booking' do
   scenario 'I can go to /requests and see requests against my spaces' do
     user_sign_up('firstUser@gmail.com', '123')
     add_space('My Place','Amazing flat', '50')
+    click_link('Log out')
     user_sign_up('secondUser@gmail.com', '123')
     make_request('2019-04-09')
+    click_link('Log out')
     user_log_in('firstUser@gmail.com', '123')
     visit '/requests'
     expect(page).to have_content('Pending')
@@ -14,8 +16,10 @@ feature 'Confirm booking' do
   scenario 'I click accept next to a request and see status changed to confirmed' do
     user_sign_up('firstUser@gmail.com', '123')
     add_space('My Place', 'Amazing flat', '50')
+    click_link('Log out')
     user_sign_up('secondUser@gmail.com', '123')
     make_request('2019-04-09')
+    click_link('Log out')
     user_log_in('firstUser@gmail.com', '123')
     visit '/requests'
     click_button 'Accept Booking'
@@ -27,8 +31,10 @@ feature 'Confirm booking' do
   scenario 'I click reject next to a request and see status changed to rejected' do
     user_sign_up('firstUser@gmail.com', '123')
     add_space('My Place', 'Amazing flat', '50')
+    click_link('Log out')
     user_sign_up('secondUser@gmail.com', '123')
     make_request('2019-04-09')
+    click_link('Log out')
     user_log_in('firstUser@gmail.com', '123')
     visit '/requests'
     click_button 'Reject Booking'

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -21,6 +21,7 @@
       </div>
       <menu class="col">
         <ul>
+          <% if logged_in? %>
           <li>
             <a href="/requests">Requests</a>
           </li>
@@ -30,12 +31,15 @@
           <li>
             <a href="/logout">Log out</a>
           </li>
+          <% end %>
+          <% if not_logged_in? %>
           <li>
             <a name="log_in" href="/sessions/new">Log in</a>
           </li>
           <li>
             <a href="/">Sign up</a>
           </li>
+          <% end %>
         </ul>
       </menu>
     </header>


### PR DESCRIPTION
We created some helper methods to test if a user is logged in.

We also updated some of the tests because you now have to explicitly
log out befor the sign-up or log-in links will appear.