### PR TITLE
Available date range datepicker

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,9 +50,6 @@ class MakersBnB < Sinatra::Base
                                       space_id: params[:space_id])
     @booked_dates = Request.all(status: 'Confirmed',
                                 space_id: params[:space_id])
-    # p @booked_dates.first.date
-    # request = @booked_dates.first
-    # p request
     @user = current_user
     erb :"request/new"
   end

--- a/public/js/interface.js
+++ b/public/js/interface.js
@@ -1,14 +1,17 @@
 $(document).ready(function() {
-  var datesString = $("#request_date_picker").attr("data-booked-dates")
-  var availability = new Availability(datesString);
+  var bookedDatesString = $("#request_date_picker").attr("data-booked-dates")
+  var availabilityStart = $("#request_date_picker").attr("data-availability-start")
+  var availabilityEnd = $("#request_date_picker").attr("data-availability-end")
+  var availability = new Availability(bookedDatesString);
   var availability_bound = availability.dateAvailable.bind(availability)
 
-  $('#request_date_picker')
+
   $('#request_date_picker').datepicker({
-    minDate: new Date(2019, 0, 1),
-    maxDate: new Date(2019, 5, 31),
+    minDate: new Date(availabilityStart),
+    maxDate: new Date(availabilityEnd),
     dateFormat: 'yy-mm-dd',
     constrainInput: true,
-    beforeShowDay: availability_bound
+    beforeShowDay: availability_bound,
+    showAnim: 'fade'
   });
 });

--- a/spec/features/no_bookings_outside_range_spec.rb
+++ b/spec/features/no_bookings_outside_range_spec.rb
@@ -1,0 +1,12 @@
+feature 'Request a booking' do
+  scenario "a user can not request a booking outside the space's available range" do
+    user_sign_up('johnnylandlord@landlords.com', 'moneymoneymoney')
+    add_space("Bob's Bunker", 'My bunker is amazing', '50', '2019-04-20', '2019-04-29')
+    user_sign_up('billyrenter@renters.com', 'love2rent')
+    click_link 'Log out'
+    user_sign_up('renter@renter', 'password')
+    click_link 'Request to book'
+    page.should have_selector('#request_date_picker[data-availability-start="2019-04-20"]')
+    page.should have_selector('#request_date_picker[data-availability-end="2019-04-29"]')
+  end
+end

--- a/spec/features/request_a_booking_spec.rb
+++ b/spec/features/request_a_booking_spec.rb
@@ -21,13 +21,4 @@ feature 'Request a booking' do
     expect(page).to have_content "2020-07-22"
     expect(page).to have_content "Pending"
   end
-  xscenario "a user can not request a booking outside the space's available range" do
-    user_sign_up('johnnylandlord@landlords.com', 'moneymoneymoney')
-    add_space("Bob's Bunker", 'My bunker is amazing', '50', '2019-04-20', '2019-04-29')
-    user_sign_up('billyrenter@renters.com', 'love2rent')
-    visit '/spaces'
-    click_link 'Request to book'
-    expect(find('#request_date_picker')['min']).to eq('2019-04-20')
-    expect(find('#request_date_picker')['max']).to eq('2019-04-29')
-  end
 end

--- a/views/request/new.erb
+++ b/views/request/new.erb
@@ -6,7 +6,11 @@
             <input type="hidden" name="space_id" value="<%= @space.id %>">
             <div class="form-group">
                 <label for="booking_date">Booking date</label>
-                <input type="text" id="request_date_picker" data-booked-dates="<%= booked_dates_string(@confirmed_requests) %>" class="form-control" name="booking_date" min='<%= @space.start_date %>' max='<%= @space.end_date %>' placeholder='yyyy-mm-dd'>
+                <input type="text" id="request_date_picker"
+                       data-availability-start="<%= @space.start_date %>"
+                       data-availability-end="<%= @space.end_date %>"
+                       data-booked-dates="<%= booked_dates_string(@confirmed_requests) %>"
+                       class="form-control" name="booking_date">
             </div>
             <button type="submit" class="btn btn-primary">Request to book</button>
         </form>


### PR DESCRIPTION
Min and max dates are included in the requests/new html now and our javascript interface extracts these and passes them into datepicker. Users can no longer select dates outside of available range.